### PR TITLE
Change wording and link duplicate instructions

### DIFF
--- a/challenge/de_rest.md
+++ b/challenge/de_rest.md
@@ -1,6 +1,6 @@
 # Startnext Coding Challenge
 
-Forke dieses Repository in ein privates Repository und füge @verbunden (Benjamin Brandt) und @frzb (Gunter Miegel) als Mitarbeiter hinzu. 
+[Dupliziere][duplicate] dieses Repository in ein privates Repository und füge @verbunden (Benjamin Brandt) und @frzb (Gunter Miegel) als Mitwirkende hinzu.
 
 > Entwerfe eine einfache REST API die Teil einer Crowdfunding-Platform sein könnte.
 > Implementiere diese API in einem RESTful Webservice.
@@ -47,3 +47,5 @@ Diese Punkte sind optional - hier einige Anregungen was Du zusaetzlich noch mach
 - CI/CD
 - Implementierung als Microservices
 - Weiterer API-Endpunkt in anderer Programmiersprache
+
+[duplicate]: https://docs.github.com/de/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/duplicating-a-repository

--- a/challenge/en_rest.md
+++ b/challenge/en_rest.md
@@ -1,6 +1,6 @@
 # Startnext Coding Challenge
 
-Fork this repository in private repository and add @verbunden (Benjamin Brandt) and @frzb (Gunter Miegel) as collaborators.
+[Duplicate][duplicate] this repository in private repository and add @verbunden (Benjamin Brandt) and @frzb (Gunter Miegel) as collaborators.
 
 > Design a simple REST API which could be used as part of a Crowdfunding platform.
 > Implement this API as a RESTful web service.
@@ -47,3 +47,5 @@ These are optional topics - here some inspirations of additional things to do
 - CI/CD
 - Implementation as micro services
 - Additional API endpoint in another programming language
+
+[duplicate]: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/duplicating-a-repository


### PR DESCRIPTION
Addresses and fixes #1.

- Add link to instructions for how to duplicate a repository
- Changed german Mitarbeiter to Mitwirkende to better align with GitHub terminology